### PR TITLE
Update version regexp and strip hashes from filenames

### DIFF
--- a/app/ArtifactUtils.php
+++ b/app/ArtifactUtils.php
@@ -12,23 +12,12 @@ abstract class ArtifactUtils {
    * @return string
    */
   public static function generalizeName(string $name): string {
-
-    // Find last continuous alpha sequence beginning with a dot, and assume it's the extension
-    $has_extension = preg_match('/((\.[a-z][a-z0-9]+)+)$/i', $name, $matches);
-    if ($has_extension !== 1) {
-      $extension = '';
-      $basename = $name;
-    } else {
-      $extension = $matches[0];
-      $basename = substr($name, 0, -strlen($extension));
-    }
-
-    // Strip version numbers just from the basename
-    $basename = preg_replace(
-      '/([0-9][0-9\.\-_]+)/',
+    // Strip version numbers
+    $name = preg_replace(
+      '/([0-9]+(\.[0-9_-]+)+)/',
       static::VERSION_PLACEHOLDER,
-      $basename
+      $name
     );
-    return $basename . $extension;
+    return $name;
   }
 }

--- a/app/ArtifactUtils.php
+++ b/app/ArtifactUtils.php
@@ -3,6 +3,7 @@
 namespace App;
 
 abstract class ArtifactUtils {
+  const HASH_PLACEHOLDER = '[hash]';
   const VERSION_PLACEHOLDER = '[version]';
 
   /**
@@ -12,6 +13,14 @@ abstract class ArtifactUtils {
    * @return string
    */
   public static function generalizeName(string $name): string {
+    // Strip hashes
+    // Match hex hashes betwen 20 (webpack truncated default) and 64 (sha256) characters.
+    $name = preg_replace(
+      '/([a-f0-9]{20,64})/i',
+      static::HASH_PLACEHOLDER,
+      $name
+    );
+
     // Strip version numbers
     $name = preg_replace(
       '/([0-9]+(\.[0-9_-]+)+)/',

--- a/tests/Unit/ArtifactUtilsTest.php
+++ b/tests/Unit/ArtifactUtilsTest.php
@@ -21,6 +21,9 @@ class ArtifactUtilsTest extends TestCase {
       ['yarn-1.0.0_20170905.1413-1.noarch.rpm', 'yarn-[version].noarch.rpm'],
       ['hello-world.sqlite3', 'hello-world.sqlite3'],
       ['babel.js', 'babel.js'],
+      ['babel.3e0de52baee579f5b435.js', 'babel.[hash].js'],
+      ['babel.v2.4.1.3e0de52baee579f5b435.js', 'babel.v[version].[hash].js'],
+      ['overenthusiastically.js', 'overenthusiastically.js'],
       ['noextension', 'noextension'],
     ];
   }


### PR DESCRIPTION
Hey @Daniel15,

This "detects" hashes from filenames and removes them. As you can see in [this PR](https://github.com/armateam/extension/pull/35), it gets a little messy when there are hashes in the filename.

The detected hashes are sequences of hex chars with a length from 20 (webpack truncated default) to 64 (sha256).

In theory there can be some false positives, let’s say with a filename that has a 20-chars-long word with only [a-f] characters in it. If that happens maybe we can be a little more specific.

I also updated the version regexp to get rid of the extension matching by making it a little less greedy.