### PR TITLE
Re-enable failure status

### DIFF
--- a/app/Listeners/GitHubStatusListener.php
+++ b/app/Listeners/GitHubStatusListener.php
@@ -35,7 +35,7 @@ class GitHubStatusListener {
         } else {
           $description .= ' (increased by ' . Format::fileSize(-$diff) . ', ' . -$diff_percent . '%)';
           if ($diff < static::WARN_THRESHOLD) {
-            //$state = 'failure';
+            $state = 'failure';
           }
         }
       }


### PR DESCRIPTION
It was commented out it https://github.com/Daniel15/BuildSize/commit/659e6fea871265347d5d757cd8f8ea186fc4d7b9#diff-ec5c124326cf93ffb0186797120d22edR234
but that looks like possibly a mistake?