### PR TITLE
display status of largest diff instead of total

### DIFF
--- a/app/Listeners/GitHubCommentListener.php
+++ b/app/Listeners/GitHubCommentListener.php
@@ -125,18 +125,7 @@ class GitHubCommentListener {
 
   private function buildMessage(array $artifacts, int $base_total_size, int $total_size) {
     $diff = $base_total_size - $total_size;
-    $message = $diff > 0
-      ? (
-        'This change will decrease the build size from ' . Format::fileSize($base_total_size) . ' to ' .
-        Format::fileSize($total_size) . ', a decrease of ' .
-        Format::diffFileSizeWithPercentage($total_size, $base_total_size)
-      ) : (
-        'This change will increase the build size from ' . Format::fileSize($base_total_size) . ' to ' .
-        Format::fileSize($total_size) . ', an increase of ' .
-        Format::diffFileSizeWithPercentage($base_total_size, $total_size)
-      );
-
-    $message .= <<<EOT
+    $message = <<<EOT
 
 
 | File name | Previous Size | New Size | Change |

--- a/app/Listeners/GitHubStatusListener.php
+++ b/app/Listeners/GitHubStatusListener.php
@@ -20,27 +20,42 @@ class GitHubStatusListener {
    * @return void
    */
   public function handle(BuildCompletedEvent $event) {
-    $description = 'Build size: ' . Format::fileSize($event->total_size);
     $state = 'success';
-
     if ($event->has_base_build) {
-      // Can compare to base
-      $diff = $event->base_total_size - $event->total_size;
-      if (abs($diff) === 0) {
-       $description .= ' (no change)';
+
+      $largestChange = null;
+      $largestDiff = 0;
+
+      foreach ($event->build_artifacts as $artifact) {
+        if (!$event->base_build_artifacts->has($artifact->project_artifact_id)) {
+          // No base version, so nothing to compare to
+          continue;
+        }
+        $base_artifact = $event->base_build_artifacts->get($artifact->project_artifact_id);
+        $diff = $base_artifact->size - $artifact->size;
+        if(abs($diff) > $largestDiff) {
+          $largestChange = $artifact;
+          $largestDiff = $diff;
+        }
+      }
+
+      if($largestDiff === 0) {
+        $description = 'No change';
       } else if (abs($diff) < config('buildsize.github.trivial_size')) {
-        $description .= ' (no significant change)';
+        $description = 'No significant change';
       } else {
         $diff_percent = round($diff / $event->base_total_size * 100.0, 2);
         if ($diff > 0) {
-          $description .= ' (decreased by ' . Format::fileSize($diff) . ', ' . $diff_percent . '%)';
+          $description = 'Significant change of ' . $largestChange->filename . ' down by ' . Format::fileSize($diff) . ' (' . $diff_percent . '%)';
         } else {
-          $description .= ' (increased by ' . Format::fileSize(-$diff) . ', ' . -$diff_percent . '%)';
+          $description = 'Significant change of ' . $largestChange->filename . ' up by ' . Format::fileSize(-$diff) . ' (' . -$diff_percent . '%)';
           if ($diff < static::WARN_THRESHOLD) {
             //$state = 'failure';
           }
         }
       }
+    } else {
+      $description = 'No prior size to compare - ' . Format::fileSize($event->total_size);
     }
 
     $github = GithubUtils::createClientForInstall($event->install);
@@ -49,7 +64,7 @@ class GitHubStatusListener {
       $event->project->repo_name,
       $event->build->commit,
       [
-        'context' => config('buildsize.github.status_context_prefix') . '/total',
+        'context' => config('buildsize.github.status_context_prefix'),
         'description' => $description,
         'state' => $state,
         'target_url' => 'https://buildsize.org/', // TODO


### PR DESCRIPTION
as discussed here https://github.com/Daniel15/BuildSize/issues/31
Demos can be seen here https://github.com/Toxicable/angular-bazel-example/pulls - ignore the status under `/total` I couldn't make it go away after changing it to maxdiff

Im open for suggestions on wording to cut it down a bit, since it can easily over run the status box