### PR TITLE
Make sure that placeholders in comments end with '|'

### DIFF
--- a/app/Listeners/GitHubCommentListener.php
+++ b/app/Listeners/GitHubCommentListener.php
@@ -145,8 +145,8 @@ class GitHubCommentListener {
 EOT;
     foreach ($artifacts as $artifact) {
       $message .= '| ' . $artifact['name'] . ' | ';
-      $message .= $this->renderFileSizeCell($artifact['old_size'], $artifact['old_url'], '[new file]');
-      $message .= $this->renderFileSizeCell($artifact['new_size'], $artifact['new_url'], '[deleted]');
+      $message .= $this->renderFileSizeCell($artifact['old_size'], $artifact['old_url'], '[new file]') . ' | ';
+      $message .= $this->renderFileSizeCell($artifact['new_size'], $artifact['new_url'], '[deleted]') . ' | ';
       if ($artifact['old_size'] !== null && $artifact['new_size'] !== null) {
         $message .= Format::diffFileSizeWithPercentage($artifact['old_size'], $artifact['new_size']) . ' | ';
       } else {
@@ -166,7 +166,7 @@ EOT;
     if (!empty($url)) {
       $result = '[' . $result . '](' . $url . ')';
     }
-    return $result . ' | ';
+    return $result;
   }
 
   private function checkForExistingComment(


### PR DESCRIPTION
This would cause “[new file]” and the size to be in the same cell.

See https://github.com/etalab/geo.data.gouv.fr/pull/594#issuecomment-363394469.