### PR TITLE
Use unbreakable spaces in Format::fileSize

### DIFF
--- a/app/Helpers/Format.php
+++ b/app/Helpers/Format.php
@@ -15,7 +15,7 @@ abstract class Format {
    */
   public static function fileSize(int $size): string {
     if ($size === 0) {
-      return '0 bytes';
+      return '0 bytes';
     }
     $negative = false;
     if ($size < 0) {
@@ -23,7 +23,7 @@ abstract class Format {
       $size = -$size;
     }
     $base = log($size, 1024);
-    $suffixes = [' bytes', ' KB', ' MB', ' GB', ' TB'];
+    $suffixes = [' bytes', ' KB', ' MB', ' GB', ' TB'];
     $result = round(pow(1024, $base - floor($base)), 2) . $suffixes[floor($base)];
     return $negative ? ('-' . $result) : $result;
   }

--- a/tests/Unit/FormatTest.php
+++ b/tests/Unit/FormatTest.php
@@ -7,24 +7,24 @@ use Tests\TestCase;
 
 class FormatTest extends TestCase {
   public function testFileSize() {
-    $this->assertEquals('-2 bytes', Format::fileSize(-2));
-    $this->assertEquals('0 bytes', Format::fileSize(0));
-    $this->assertEquals('2 bytes', Format::fileSize(2));
-    $this->assertEquals('1 KB', Format::fileSize(1024));
-    $this->assertEquals('5.42 KB', Format::fileSize(5555));
-    $this->assertEquals('1 MB', Format::fileSize(1048576));
-    $this->assertEquals('-4.14 MB', Format::fileSize(-4343425));
+    $this->assertEquals('-2 bytes', Format::fileSize(-2));
+    $this->assertEquals('0 bytes', Format::fileSize(0));
+    $this->assertEquals('2 bytes', Format::fileSize(2));
+    $this->assertEquals('1 KB', Format::fileSize(1024));
+    $this->assertEquals('5.42 KB', Format::fileSize(5555));
+    $this->assertEquals('1 MB', Format::fileSize(1048576));
+    $this->assertEquals('-4.14 MB', Format::fileSize(-4343425));
   }
 
   public function testNewFileSizeWithPercentage() {
-    $this->assertEquals('100 bytes (100%)', Format::newFileSizeWithPercentage(50, 100));
-    $this->assertEquals('100 bytes (0%)', Format::newFileSizeWithPercentage(100, 100));
-    $this->assertEquals('100 bytes (50%)', Format::newFileSizeWithPercentage(200, 100));
+    $this->assertEquals('100 bytes (100%)', Format::newFileSizeWithPercentage(50, 100));
+    $this->assertEquals('100 bytes (0%)', Format::newFileSizeWithPercentage(100, 100));
+    $this->assertEquals('100 bytes (50%)', Format::newFileSizeWithPercentage(200, 100));
   }
 
   public function testDiffFileSizeWithPercentage() {
-    $this->assertEquals('50 bytes (100%)', Format::diffFileSizeWithPercentage(50, 100));
-    $this->assertEquals('0 bytes (0%)', Format::diffFileSizeWithPercentage(100, 100));
-    $this->assertEquals('-100 bytes (50%)', Format::diffFileSizeWithPercentage(200, 100));
+    $this->assertEquals('50 bytes (100%)', Format::diffFileSizeWithPercentage(50, 100));
+    $this->assertEquals('0 bytes (0%)', Format::diffFileSizeWithPercentage(100, 100));
+    $this->assertEquals('-100 bytes (50%)', Format::diffFileSizeWithPercentage(200, 100));
   }
 }


### PR DESCRIPTION
This will prevent units from wrapping to the next line.

See https://github.com/etalab/geo.data.gouv.fr/pull/594#issuecomment-363394469 again.